### PR TITLE
 prevent 500 return when no labels are found

### DIFF
--- a/component/mongodb_repository.go
+++ b/component/mongodb_repository.go
@@ -87,6 +87,9 @@ func (r *mongoRepository) ListAllLabels() (cLabels models.ComponentLabels, err e
 	group := bson.M{"$group": bson.M{"_id": nil, "labels": bson.M{"$addToSet": "$labels"}}}
 	pipeline := []bson.M{unwind, group}
 	err = r.db.DB(databaseName).C("Component").Pipe(pipeline).One(&cLabels)
+	if err == mgo.ErrNotFound {
+		return cLabels, nil
+	}
 	return cLabels, err
 }
 

--- a/component/mongodb_repository_test.go
+++ b/component/mongodb_repository_test.go
@@ -34,6 +34,19 @@ func TestComponentMongoDB_Repository_NewMongoRepository(t *testing.T) {
 	assert.Implements(t, (*component.Repository)(nil), repo)
 }
 
+func TestComponentMongoDB_Repository_ListAllLabels(t *testing.T) {
+	repo := component.NewMongoRepository(testSession)
+
+	cLabels, err := repo.ListAllLabels()
+	assert.Nil(t, err)
+	assert.NotNil(t, cLabels)
+
+	repo = component.NewMongoRepository(failureSession)
+	_, err = repo.ListAllLabels()
+	assert.NotNil(t, err)
+
+}
+
 func TestComponentMongoDB_Repository_Insert(t *testing.T) {
 
 	repo := component.NewMongoRepository(testSession)
@@ -140,19 +153,6 @@ func TestComponentMongoDB_Repository_List(t *testing.T) {
 	repo = component.NewMongoRepository(failureSession)
 	_, err = repo.List()
 	assert.NotNil(t, err)
-}
-
-func TestComponentMongoDB_Repository_ListAllLabels(t *testing.T) {
-	repo := component.NewMongoRepository(testSession)
-
-	cLabels, err := repo.ListAllLabels()
-	assert.Nil(t, err)
-	assert.NotNil(t, cLabels)
-
-	repo = component.NewMongoRepository(failureSession)
-	_, err = repo.ListAllLabels()
-	assert.NotNil(t, err)
-
 }
 
 func TestComponentMongoDB_Repository_FindAll(t *testing.T) {


### PR DESCRIPTION
On a fresh start database with no components with labels, the listing labels endpoint would return a 500 http status when a empty list would fit nicely.