### PR TITLE
Create logger example to validate model

### DIFF
--- a/client/controller_test.go
+++ b/client/controller_test.go
@@ -22,7 +22,7 @@ const (
 )
 
 var router = gin.Default()
-var compSvc = component.NewService(mock.NewMockComponentDAO())
+var compSvc = component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 func init() {
 	clientService := client.NewService(mock.NewMockClientDAO(), compSvc)

--- a/client/service_test.go
+++ b/client/service_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestNewClientService(t *testing.T) {
 	dao := mock.NewMockClientDAO()
-	assert.Implements(t, (*client.Service)(nil), client.NewService(dao, component.NewService(mock.NewMockComponentDAO())))
+	assert.Implements(t, (*client.Service)(nil), client.NewService(dao, component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())))
 }
 
 func TestClientService_CreateClient(t *testing.T) {
-	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO()))
+	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()))
 	c := models.Client{
 		Name:      "test",
 		Resources: make([]string, 0),
@@ -47,7 +47,7 @@ func TestClientService_CreateClient(t *testing.T) {
 
 }
 func TestClientService_FindClient(t *testing.T) {
-	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO()))
+	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()))
 
 	c, err := s.FindClient(map[string]interface{}{"ref": mock.ZeroTimeHex})
 	if assert.Nil(t, err) && assert.NotNil(t, c) {
@@ -73,7 +73,7 @@ func TestClientService_FindClient(t *testing.T) {
 	assert.NotNil(t, err)
 }
 func TestClientService_ListClients(t *testing.T) {
-	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO()))
+	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()))
 
 	c, err := s.ListClients()
 	if assert.Nil(t, err) && assert.NotNil(t, c) {
@@ -84,7 +84,7 @@ func TestClientService_ListClients(t *testing.T) {
 	}
 }
 func TestClientService_RemoveClient(t *testing.T) {
-	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO()))
+	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()))
 	err := s.RemoveClient(mock.OneSecTimeHex)
 	assert.Nil(t, err)
 
@@ -92,7 +92,7 @@ func TestClientService_RemoveClient(t *testing.T) {
 	assert.NotNil(t, err)
 }
 func TestClientService_UpdateClient(t *testing.T) {
-	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO()))
+	s := client.NewService(mock.NewMockClientDAO(), component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()))
 
 	c, err := s.FindClient(map[string]interface{}{"ref": mock.ZeroTimeHex})
 	assert.Nil(t, err)

--- a/component/controller_test.go
+++ b/component/controller_test.go
@@ -23,8 +23,8 @@ const (
 var router = gin.Default()
 
 func init() {
-	componentService := component.NewService(mock.NewMockComponentDAO())
-	componentFailureService := component.NewService(mock.NewMockFailureComponentDAO())
+	componentService := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
+	componentFailureService := component.NewService(mock.NewMockFailureComponentDAO(), mock.NewComponentLogRepositoryMock())
 	component.Router(componentService, router.Group(routerGroupName))
 	component.Router(componentFailureService, router.Group(failureRouterGroupName))
 }

--- a/component/interface.go
+++ b/component/interface.go
@@ -36,3 +36,10 @@ type Service interface {
 	ListAllLabels() (models.ComponentLabels, error)
 	ListComponentsWithLabels(labels models.ComponentLabels) ([]models.Component, error)
 }
+
+//Log describes how loggers implementation will behave
+type Log interface {
+	Error(ojb models.Component, logMessage string)
+	Info(obj models.Component, logMessage string)
+	Warn(obj models.Component, logMessage string)
+}

--- a/component/service.go
+++ b/component/service.go
@@ -7,26 +7,32 @@ import (
 
 type componentService struct {
 	repo Repository
+	log  Log
 }
 
 //NewService creates implementation of the Service interface
-func NewService(r Repository) Service {
-	return &componentService{repo: r}
+func NewService(r Repository, l Log) Service {
+	return &componentService{repo: r, log: l}
 }
 
 func (s *componentService) CreateComponent(component models.Component) (string, error) {
+	s.log.Info(component, "Attempting to create a new component")
 	if valid, err := s.isValidComponent(component); !valid {
+		s.log.Error(component, "Component creation failed, it seems this component is not valid")
 		return component.Ref, err
 	}
 
 	if inUse, err := s.isComponentNameInUse(component); inUse {
+		s.log.Error(component, "Component creation failed, it seems this component name already exists")
 		return component.Ref, err
 	}
 
 	if inUse, err := s.isComponentRefInUse(component); inUse {
+		s.log.Error(component, "Component creation failed, it seems this component reference already exists")
 		return component.Ref, err
 	}
 
+	s.log.Info(component, "Validations passed! creating new component")
 	return s.repo.Insert(component)
 }
 

--- a/component/service_test.go
+++ b/component/service_test.go
@@ -15,13 +15,13 @@ import (
 
 func TestNewComponentService(t *testing.T) {
 	dao := mock.NewMockComponentDAO()
-	s := component.NewService(dao)
+	s := component.NewService(dao, mock.NewComponentLogRepositoryMock())
 	assert.Implements(t, (*component.Service)(nil), s)
 
 }
 
 func TestComponentService_ListComponents(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	refs := make([]string, 0)
 	c, err := s.ListComponents(refs)
@@ -33,7 +33,7 @@ func TestComponentService_ListComponents(t *testing.T) {
 	}
 }
 func TestComponentService_FindComponent(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	c, err := s.FindComponent(map[string]interface{}{"ref": mock.ZeroTimeHex})
 	if assert.Nil(t, err) && assert.NotNil(t, c) {
@@ -69,7 +69,7 @@ func TestComponentService_FindComponent(t *testing.T) {
 
 }
 func TestComponentService_CreateComponent(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	c := models.Component{
 		Ref:     bson.NewObjectIdWithTime(bson.Now().Add(5 * time.Second)).Hex(),
@@ -100,7 +100,7 @@ func TestComponentService_CreateComponent(t *testing.T) {
 
 }
 func TestComponentService_UpdateComponent(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	currTime := bson.Now().String()
 	c, err := s.FindComponent(map[string]interface{}{"ref": mock.ZeroTimeHex})
@@ -124,7 +124,7 @@ func TestComponentService_UpdateComponent(t *testing.T) {
 
 }
 func TestComponentService_RemoveComponent(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	err := s.RemoveComponent(mock.ZeroTimeHex)
 	assert.Nil(t, err)
@@ -133,7 +133,7 @@ func TestComponentService_RemoveComponent(t *testing.T) {
 	assert.NotNil(t, err)
 }
 func TestComponentService_componentExists(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	c, err := s.FindComponent(map[string]interface{}{"ref": mock.ZeroTimeHex})
 	if assert.Nil(t, err) && assert.NotNil(t, c) {
@@ -149,7 +149,7 @@ func TestComponentService_componentExists(t *testing.T) {
 }
 
 func TestComponentService_ListAllLabels(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	c := models.Component{
 		Ref:     bson.NewObjectIdWithTime(bson.Now().Add(5 * time.Second)).Hex(),
@@ -168,7 +168,7 @@ func TestComponentService_ListAllLabels(t *testing.T) {
 
 }
 func TestComponentService_ListComponentsWithLabels(t *testing.T) {
-	s := component.NewService(mock.NewMockComponentDAO())
+	s := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 	c := models.Component{
 		Name:    "New Component",

--- a/incident/controller_test.go
+++ b/incident/controller_test.go
@@ -22,7 +22,7 @@ const routerGroupName = "/test"
 const failureRouterGroupName = "/failure"
 
 var router = gin.Default()
-var componentService = component.NewService(mock.NewMockComponentDAO())
+var componentService = component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 
 func init() {
 	incidentService := incident.NewService(mock.NewMockIncidentDAO(), componentService)

--- a/incident/service_test.go
+++ b/incident/service_test.go
@@ -16,14 +16,14 @@ import (
 
 func TestNewIncidentService(t *testing.T) {
 	incidentDAO := mock.NewMockIncidentDAO()
-	componentService := component.NewService(mock.NewMockComponentDAO())
+	componentService := component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock())
 	s := incident.NewService(incidentDAO, componentService)
 	assert.Implements(t, (*incident.Service)(nil), s)
 }
 func TestIncidentService_ListIncidents(t *testing.T) {
 	s := incident.NewService(
 		mock.NewMockIncidentDAO(),
-		component.NewService(mock.NewMockComponentDAO()),
+		component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()),
 	)
 
 	params := models.ListIncidentQueryParameters{
@@ -94,7 +94,7 @@ func TestIncidentService_ListIncidents(t *testing.T) {
 func TestIncidentService_CreateIncident(t *testing.T) {
 	s := incident.NewService(
 		mock.NewMockIncidentDAO(),
-		component.NewService(mock.NewMockComponentDAO()),
+		component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()),
 	)
 
 	i := models.Incident{
@@ -139,7 +139,7 @@ func TestIncidentService_CreateIncident(t *testing.T) {
 func TestIncidentService_FindIncidents(t *testing.T) {
 	s := incident.NewService(
 		mock.NewMockIncidentDAO(),
-		component.NewService(mock.NewMockComponentDAO()),
+		component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()),
 	)
 
 	i, err := s.FindIncidents(map[string]interface{}{"component_ref": mock.ZeroTimeHex})
@@ -160,7 +160,7 @@ func TestIncidentService_FindIncidents(t *testing.T) {
 func TestIncidentService_ValidateMonth(t *testing.T) {
 	s := incident.NewService(
 		mock.NewMockIncidentDAO(),
-		component.NewService(mock.NewMockComponentDAO()),
+		component.NewService(mock.NewMockComponentDAO(), mock.NewComponentLogRepositoryMock()),
 	)
 
 	start := time.Time{}

--- a/logs/component_logs.go
+++ b/logs/component_logs.go
@@ -1,0 +1,15 @@
+package logs
+
+import "github.com/involvestecnologia/statuspage/models"
+
+func (l *logRepository) Info(obj models.Component, logMessage string) {
+	l.info(obj, logMessage)
+}
+
+func (l *logRepository) Error(obj models.Component, logMessage string) {
+	l.error(obj, logMessage)
+}
+
+func (l *logRepository) Warn(obj models.Component, logMessage string) {
+	l.warn(obj, logMessage)
+}

--- a/logs/logrus.go
+++ b/logs/logrus.go
@@ -1,0 +1,38 @@
+package logs
+
+import (
+	"github.com/involvestecnologia/statuspage/component"
+	"github.com/sirupsen/logrus"
+)
+
+type logRepository struct {
+	logger *logrus.Logger
+}
+
+//NewLogRepository creates a new logger instance
+func NewLogRepository(logger *logrus.Logger) component.Log {
+	return &logRepository{
+		logger: logger,
+	}
+}
+
+//Info logs something to stdout as INFO
+func (l *logRepository) info(arg interface{}, logMessage string) {
+	l.logger.WithFields(logrus.Fields{
+		"obj": arg,
+	}).Info(logMessage)
+}
+
+//Warn logs somehting to stdout as Warn
+func (l *logRepository) warn(arg interface{}, logMessage string) {
+	l.logger.WithFields(logrus.Fields{
+		"obj": arg,
+	}).Warn(logMessage)
+}
+
+//Error logs something to stdout as Error
+func (l *logRepository) error(arg interface{}, logMessage string) {
+	l.logger.WithFields(logrus.Fields{
+		"obj": arg,
+	}).Error(logMessage)
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/gin-gonic/gin"
@@ -9,15 +8,32 @@ import (
 	"github.com/involvestecnologia/statuspage/component"
 	"github.com/involvestecnologia/statuspage/db"
 	"github.com/involvestecnologia/statuspage/incident"
+	"github.com/involvestecnologia/statuspage/logs"
 	"github.com/involvestecnologia/statuspage/middleware"
 	"github.com/involvestecnologia/statuspage/prometheus"
+	"github.com/sirupsen/logrus"
 )
 
+var log = logrus.New()
+
 func main() {
+
+	log.Out = os.Stdout
+
 	mgouri, exist := os.LookupEnv("MONGO_URI")
 	if !exist {
 		log.Panic("MongoDB URI not informed")
 	}
+
+	env, exist := os.LookupEnv("ENV_MODE")
+	if !exist {
+		log.Panic("MongoDB URI not informed")
+	}
+	if env == "production" {
+		log.SetFormatter(&logrus.JSONFormatter{})
+		log.SetLevel(logrus.ErrorLevel)
+	}
+
 	session := db.InitMongo(mgouri)
 
 	router := gin.Default()
@@ -29,9 +45,10 @@ func main() {
 	componentRepository := component.NewMongoRepository(session)
 	incidentRepository := incident.NewMongoRepository(session)
 	clientRepository := client.NewMongoRepository(session)
+	componentLogRepository := logs.NewLogRepository(log)
 
 	// Initialize services
-	componentService := component.NewService(componentRepository)
+	componentService := component.NewService(componentRepository, componentLogRepository)
 	incidentService := incident.NewService(incidentRepository, componentService)
 	clientService := client.NewService(clientRepository, componentService)
 

--- a/mock/log.go
+++ b/mock/log.go
@@ -1,0 +1,25 @@
+package mock
+
+import (
+	"github.com/involvestecnologia/statuspage/component"
+	"github.com/involvestecnologia/statuspage/models"
+)
+
+type componentLogRepositoryMock struct {
+}
+
+func NewComponentLogRepositoryMock() component.Log {
+	return &componentLogRepositoryMock{}
+}
+
+func (mock *componentLogRepositoryMock) Info(obj models.Component, logMessage string) {
+	return
+}
+
+func (mock *componentLogRepositoryMock) Error(obj models.Component, logMessage string) {
+	return
+}
+
+func (mock *componentLogRepositoryMock) Warn(obj models.Component, logMessage string) {
+	return
+}

--- a/models/component.go
+++ b/models/component.go
@@ -17,3 +17,9 @@ type ComponentRefs struct {
 type ComponentLabels struct {
 	Labels []string `json:"labels,omitempty" binding:"required"`
 }
+
+type ComponentLog struct {
+	ComponentName string
+	Address       string
+	LogMessage    string
+}

--- a/prometheus/controller_test.go
+++ b/prometheus/controller_test.go
@@ -19,7 +19,7 @@ var router = gin.New()
 func init() {
 	componentDAO := mock.NewMockComponentDAO()
 	incidentDAO := mock.NewMockIncidentDAO()
-	componentService := component.NewService(componentDAO)
+	componentService := component.NewService(componentDAO, mock.NewComponentLogRepositoryMock())
 	incidentService := incident.NewService(incidentDAO, componentService)
 	Router(incidentService, componentService, router.Group("/v1"))
 }

--- a/prometheus/routes_test.go
+++ b/prometheus/routes_test.go
@@ -16,7 +16,7 @@ func TestPrometheusRouter_PrometheusRouter(t *testing.T) {
 
 	componentDAO := mock.NewMockComponentDAO()
 	incidentDAO := mock.NewMockIncidentDAO()
-	componentService := component.NewService(componentDAO)
+	componentService := component.NewService(componentDAO, mock.NewComponentLogRepositoryMock())
 	incidentService := incident.NewService(incidentDAO, componentService)
 
 	Router(incidentService, componentService, router.Group("/v1"))

--- a/prometheus/service_test.go
+++ b/prometheus/service_test.go
@@ -14,16 +14,16 @@ func NewServicesMock(failure bool, m string) Service {
 	componentFailureDAO := mock.NewMockFailureComponentDAO()
 	incidentDAO := mock.NewMockIncidentDAO()
 	incidentFailureDAO := mock.NewMockFailureIncidentDAO()
-	componentService := component.NewService(componentDAO)
+	componentService := component.NewService(componentDAO, mock.NewComponentLogRepositoryMock())
 	incidentService := incident.NewService(incidentDAO, componentService)
 
 	if failure {
 		if m == "incident" {
-			componentService = component.NewService(componentDAO)
+			componentService = component.NewService(componentDAO, mock.NewComponentLogRepositoryMock())
 			incidentService = incident.NewService(incidentFailureDAO, componentService)
 		}
 		if m == "component" {
-			componentService = component.NewService(componentFailureDAO)
+			componentService = component.NewService(componentFailureDAO, mock.NewComponentLogRepositoryMock())
 			incidentService = incident.NewService(incidentDAO, componentService)
 		}
 	}


### PR DESCRIPTION
The idea is that each package must have a log interface matching its models.

Example:
The component model would have the following log interface 

```golang
 type Log interface {
	Error(ojb models.Component, logMessage string)
	Info(obj models.Component, logMessage string)
	Warn(obj models.Component, logMessage string)
}
```

And of course, the logs package would have to implement this interface.

**What about code duplicity?**

the log package has private functions that do the main "logging" all other methods are just for interface fulfillment.

In the main application, we would have only one log repository as follows

```golang
logRepository := logs.NewLogRepository(log)
```

Production mode vs Dev mode

If the environment `ENV` is set to production the default log formatter will be json, the log level will be ERROR, and the log output will look like this:
![logrus-json](https://user-images.githubusercontent.com/12124856/55368203-117adb00-54c7-11e9-924d-87ff87f76763.png)

if the environment ENV is not set  the default log formatter will be text, the log level will be INFO, and the output will look like this:
![colored](https://user-images.githubusercontent.com/12124856/55368237-340cf400-54c7-11e9-80e1-57eba38f017b.png)


The problem is: 
How will we log for methods like this?
```golang
func (s *componentService) FindComponent(queryParam map[string]interface{}) (models.Component, error) {
	if len(queryParam) == 0 {
		return models.Component{}, &errors.ErrInvalidQuery{Message: errors.ErrInvalidQueryMessage}
	}
	return s.repo.Find(queryParam)
}
```

I think 
```
s.log.Info(models.Component{}).Error("Sorry your query is wrong")

``` 
 is not a good idea.

Should the interface be like this?
```golang
 type Log interface {
	Error(ojb interface{}, logMessage string)
	Info(obj interface{}, logMessage string)
	Warn(obj interface{}, logMessage string)
}
```
Which I don't think is a nice idea as well.
